### PR TITLE
Use getopt for configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SYSFS_BACKLIGHT_PATH = /sys/class/backlight/intel_backlight/
-DIM_PERCENT_TIMEOUT  = 40
-DIM_PERCENT_INTERVAL = 20
 
 DESTDIR =
 PREFIX  = /usr/local
@@ -11,9 +9,8 @@ EXECUTABLE=$(SOURCE:.c=)
 X11LIBS = -lxcb-screensaver -lxcb-dpms -lxcb-randr -lxcb
 GCCLIBS = -lm
 debug_CFLAGS = -O0 -g3 -gdwarf-4 -fno-omit-frame-pointer ## framepointers are needed by valgrind
-base_CFLAGS  = -std=gnu11 -D_REENTRANT -Wall -Wextra -pedantic -O2 -D_XOPEN_SOURCE=600 -DPROGNAME=\"${EXECUTABLE}\"
-clang_CFLAGS = -Weverything
-define_FLAGS = -DDIM_PERCENT_TIMEOUT=${DIM_PERCENT_TIMEOUT} -DDIM_PERCENT_INTERVAL=${DIM_PERCENT_INTERVAL}
+base_CFLAGS  = -std=gnu11 -D_REENTRANT -Wall -Wextra  -pedantic -O2 -D_XOPEN_SOURCE=600 -DPROGNAME=\"${EXECUTABLE}\"
+clang_CFLAGS = -Weverything -Wno-disabled-macro-expansion
 
 CC = clang
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ Use `xset s 240 60` to set `timeout` to 240 seconds and `cycle` to 60 seconds, r
 
 True. _brightnessd_ was done just for fun and to code some application in C using [xcb](http://xcb.freedesktop.org/).
 
-#### Why is most configuration possible at compile-time only? ####
-
-I didn't feel the need to implement, e.g., [getopt](http://www.gnu.org/software/libc/manual/html_node/Getopt.html). However, if you do, Pull Requests are very welcome :)
-
 #### brightnessd behaves strangely, what can I do? ####
 
 Please recompile _brightnessd_ with the `debug` or `debug_sysfs` `make` target, respectively, to get more information on what's going on while _brightnessd_ runs. The resulting log is usually helpful in identifying problems or bugs.

--- a/brightnessd.c
+++ b/brightnessd.c
@@ -36,6 +36,7 @@
 #include <xcb/dpms.h>
 #include <xcb/randr.h>
 
+
 #ifdef DEBUGLOG
     #define DEBUG(...) do {                                       \
         (void)fprintf(stderr, "%s", gs_color.green);              \
@@ -199,7 +200,7 @@ bool query_state(struct Tglobalstate *state, const struct Txcb *pxcb);
 bool query_state_screensaver(struct Tglobalstate *pglobalstate, const struct Txcb *pxcb);
 bool query_state_dpms(struct Tglobalstate *pglobalstate, const struct Txcb *pxcb);
 static int parse_uint8_t(char* input, uint8_t* output);
-static int parse_args(int argc, char** argv);
+static int parse_args(int len, char** args);
 #ifndef USE_SYSFS_BACKLIGHT_CONTROL
 bool _operation_handler_randr(const operations_t operation, struct Txcb *pxcb, const uint8_t brn_percent, uint8_t *brn_cur_perc, uint8_t *brn_new_perc);
 int32_t _get_brightness_randr(struct Txcb *pxcb, const xcb_randr_output_t output, const xcb_atom_t *backlight_atom);
@@ -1031,7 +1032,7 @@ static uint8_t event_loop(struct Tglobalstate *pglobalstate, struct Txcb *pxcb, 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// parse_uint8_t
+// parse_uint8_t()
 ///////////////////////////////////////////////////////////////////////////////
 /** Converts a string to an uint8_t.
 
@@ -1053,7 +1054,7 @@ static int parse_uint8_t(char* input, uint8_t* output) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// print_usage
+// print_usage()
 ///////////////////////////////////////////////////////////////////////////////
 void print_usage(void) {
     printf("Usage: brightnessd [options...]\n"
@@ -1065,15 +1066,16 @@ void print_usage(void) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// parse_args
+// parse_args()
 ///////////////////////////////////////////////////////////////////////////////
-/** Parse command-line argumens.
+/** Parses a string array (e.g. command-line arguments) and modifies the global
+    state (configuration).
 
-    @param argc           the string which should be converted
-    @param argv           a pointer in which the conversion result will be written
-    @return               a non-zero return value indicates an error
+    @param len           the length of the string array
+    @param args          an array of strings which should be parsed
+    @return              a non-zero return value indicates an error
 */
-static int parse_args(int argc, char** argv) {
+static int parse_args(int len, char** args) {
 
     int err = 0;
     int opt = 0;
@@ -1084,8 +1086,8 @@ static int parse_args(int argc, char** argv) {
         {0,                    0,                       0,  0   }
     };
 
-    int long_index =0;
-    while ((opt = getopt_long(argc, argv, "c:t:h",
+    int long_index = 0;
+    while ((opt = getopt_long(len, args, "c:t:h",
                               long_options, &long_index)) != -1) {
         switch (opt) {
         case 'c':
@@ -1096,7 +1098,7 @@ static int parse_args(int argc, char** argv) {
             break;
         case 'h':
             print_usage();
-            exit(0);
+            exit(EXIT_SUCCESS);
         default:
             print_usage();
             err = 1;
@@ -1114,11 +1116,11 @@ static int parse_args(int argc, char** argv) {
 
     @see event_loop
 */
-int main (int argc, char** argv) {
+int main(int argc, char** argv) {
 
     if (parse_args(argc, argv)) {
         ERROR("[main] Error parsing command-line arguments.\n");
-        return 1;
+        exit(EXIT_FAILURE);
     }
     DEBUG("[main] Configuration: DIM_PERCENT_INTERVAL=%d, DIM_PERCENT_TIMEOUT=%d\n", DIM_PERCENT_INTERVAL, DIM_PERCENT_TIMEOUT);
 


### PR DESCRIPTION
This is in preparation for another feature (running user-supplied commands (e.g. screen locker) on X11 events). The review process should be easier this way though. I also "fixed" compile-time warnings regarding disabled macros by ignoring them.

Implementation detail: I didn't use `atoi()` because it's evil.